### PR TITLE
Build s3backer in a docker container for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  autoconf \
+  libcurl4-openssl-dev \
+  libfuse-dev \
+  libexpat1-dev
+
+ADD . s3backer
+
+WORKDIR "./s3backer"
+
+RUN ["./autogen.sh"]
+RUN ["./configure"]
+RUN ["make"]
+RUN ["make", "install"]


### PR DESCRIPTION
This creates a container with the necessary build requirements as well
as builds and installs s3backer ready for use within the container.

Assuming, you already have a docker host, these are the build/install steps needed to run s3backer inside a docker container:

- Build the container with s3backer compiled:
```bash
$ docker build -t s3backer .
Sending build context to Docker daemon 557.1 kB
Sending build context to Docker daemon 985.6 kB

Sending build context to Docker daemon 
Step 0 : FROM ubuntu:14.04
 ---> 2d24f826cb16
Step 1 : RUN apt-get update && apt-get install -y   build-essential   autoconf   libcurl4-openssl-dev   libfuse-dev   libexpat1-dev
 ---> Using cache
 ---> e8d1507f00ac
Step 2 : ADD . s3backer
 ---> da2efcf81686
Removing intermediate container b91b12ff7d15
Step 3 : WORKDIR "./s3backer"
 ---> Running in a3512b62fd72
 ---> c303b9664113
Removing intermediate container a3512b62fd72
Step 4 : RUN ./autogen.sh
 ---> Running in 32d2647c8e34
cleaning up
running aclocal
running autoheader
running automake
[91mconfigure.ac:46: installing 'scripts/compile'
[0m[91mconfigure.ac:24: installing 'scripts/install-sh'
[0m[91mconfigure.ac:24: installing 'scripts/missing'
[0m[91mMakefile.am: installing 'scripts/depcomp'
[0mrunning autoconf
 ---> 955e928db6fb
Removing intermediate container 32d2647c8e34
Step 5 : RUN ./configure
 ---> Running in fa38fc3d93d2
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... no
checking for mawk... mawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether make sets $(MAKE)... (cached) yes
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking for style of include used by make... GNU
checking dependency style of gcc... gcc3
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.19... yes
checking for FUSE... yes
checking for curl_version in -lcurl... yes
checking for BIO_new in -lcrypto... yes
checking for XML_ParserCreate in -lexpat... yes
checking for fuse_version in -lfuse... yes
checking for compressBound in -lz... yes
checking for fallocate() support in fuse... yes
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking whether fdatasync is declared... yes
checking for ANSI C header files... (cached) yes
checking assert.h usability... yes
checking assert.h presence... yes
checking for assert.h... yes
checking ctype.h usability... yes
checking ctype.h presence... yes
checking for ctype.h... yes
checking curl/curl.h usability... yes
checking curl/curl.h presence... yes
checking for curl/curl.h... yes
checking err.h usability... yes
checking err.h presence... yes
checking for err.h... yes
checking errno.h usability... yes
checking errno.h presence... yes
checking for errno.h... yes
checking expat.h usability... yes
checking expat.h presence... yes
checking for expat.h... yes
checking pthread.h usability... yes
checking pthread.h presence... yes
checking for pthread.h... yes
checking stdarg.h usability... yes
checking stdarg.h presence... yes
checking for stdarg.h... yes
checking stddef.h usability... yes
checking stddef.h presence... yes
checking for stddef.h... yes
checking for stdint.h... (cached) yes
checking stdio.h usability... yes
checking stdio.h presence... yes
checking for stdio.h... yes
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking syslog.h usability... yes
checking syslog.h presence... yes
checking for syslog.h... yes
checking time.h usability... yes
checking time.h presence... yes
checking for time.h... yes
checking for unistd.h... (cached) yes
checking sys/queue.h usability... yes
checking sys/queue.h presence... yes
checking for sys/queue.h... yes
checking openssl/bio.h usability... yes
checking openssl/bio.h presence... yes
checking for openssl/bio.h... yes
checking openssl/buffer.h usability... yes
checking openssl/buffer.h presence... yes
checking for openssl/buffer.h... yes
checking openssl/evp.h usability... yes
checking openssl/evp.h presence... yes
checking for openssl/evp.h... yes
checking openssl/hmac.h usability... yes
checking openssl/hmac.h presence... yes
checking for openssl/hmac.h... yes
checking openssl/md5.h usability... yes
checking openssl/md5.h presence... yes
checking for openssl/md5.h... yes
checking zlib.h usability... yes
checking zlib.h presence... yes
checking for zlib.h... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating debian/Makefile
config.status: creating s3backer.spec
config.status: creating config.h
config.status: executing depfiles commands
 ---> 61e880040dc1
Removing intermediate container fa38fc3d93d2
Step 6 : RUN make
 ---> Running in 1c15b65885ba
make  all-recursive
make[1]: Entering directory `/s3backer'
Making all in debian
make[2]: Entering directory `/s3backer/debian'
make[2]: Nothing to be done for `all'.
make[2]: Leaving directory `/s3backer/debian'
make[2]: Entering directory `/s3backer'
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT main.o -MD -MP -MF .deps/main.Tpo -c -o main.o main.c
mv -f .deps/main.Tpo .deps/main.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT block_cache.o -MD -MP -MF .deps/block_cache.Tpo -c -o block_cache.o block_cache.c
mv -f .deps/block_cache.Tpo .deps/block_cache.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT block_part.o -MD -MP -MF .deps/block_part.Tpo -c -o block_part.o block_part.c
mv -f .deps/block_part.Tpo .deps/block_part.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT dcache.o -MD -MP -MF .deps/dcache.Tpo -c -o dcache.o dcache.c
mv -f .deps/dcache.Tpo .deps/dcache.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT ec_protect.o -MD -MP -MF .deps/ec_protect.Tpo -c -o ec_protect.o ec_protect.c
mv -f .deps/ec_protect.Tpo .deps/ec_protect.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT erase.o -MD -MP -MF .deps/erase.Tpo -c -o erase.o erase.c
mv -f .deps/erase.Tpo .deps/erase.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT fuse_ops.o -MD -MP -MF .deps/fuse_ops.Tpo -c -o fuse_ops.o fuse_ops.c
mv -f .deps/fuse_ops.Tpo .deps/fuse_ops.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT hash.o -MD -MP -MF .deps/hash.Tpo -c -o hash.o hash.c
mv -f .deps/hash.Tpo .deps/hash.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT http_io.o -MD -MP -MF .deps/http_io.Tpo -c -o http_io.o http_io.c
mv -f .deps/http_io.Tpo .deps/http_io.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT reset.o -MD -MP -MF .deps/reset.Tpo -c -o reset.o reset.c
mv -f .deps/reset.Tpo .deps/reset.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT s3b_config.o -MD -MP -MF .deps/s3b_config.Tpo -c -o s3b_config.o s3b_config.c
mv -f .deps/s3b_config.Tpo .deps/s3b_config.Po
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT test_io.o -MD -MP -MF .deps/test_io.Tpo -c -o test_io.o test_io.c
mv -f .deps/test_io.Tpo .deps/test_io.Po
printf 'const char *const s3backer_version = "%s";\n' "`git describe`" > gitrev.c
[91m/bin/bash: git: command not found
[0mgcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT gitrev.o -MD -MP -MF .deps/gitrev.Tpo -c -o gitrev.o gitrev.c
mv -f .deps/gitrev.Tpo .deps/gitrev.Po
gcc -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse    -pthread -lfuse   -pthread -o s3backer main.o block_cache.o block_part.o dcache.o ec_protect.o erase.o fuse_ops.o hash.o http_io.o reset.o s3b_config.o test_io.o gitrev.o  -lz -lfuse -lexpat -lcrypto -lcurl 
gcc -DHAVE_CONFIG_H -I.    -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -MT tester.o -MD -MP -MF .deps/tester.Tpo -c -o tester.o tester.c
mv -f .deps/tester.Tpo .deps/tester.Po
gcc -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse   -g -O3 -pipe -Wall -Waggregate-return -Wcast-align -Wchar-subscripts -Wcomment -Wformat -Wimplicit -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wparentheses -Wpointer-arith -Wredundant-decls -Wreturn-type -Wswitch -Wtrigraphs -Wuninitialized -Wunused -Wwrite-strings -Wshadow -Wstrict-prototypes -Wcast-qual  -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse    -pthread -lfuse   -pthread -o tester tester.o block_cache.o block_part.o dcache.o ec_protect.o erase.o hash.o http_io.o reset.o s3b_config.o test_io.o gitrev.o  -lz -lfuse -lexpat -lcrypto -lcurl 
make[2]: Leaving directory `/s3backer'
make[1]: Leaving directory `/s3backer'
 ---> 9a715ad649b1
Removing intermediate container 1c15b65885ba
Step 7 : RUN make install
 ---> Running in db018a4a0bf5
Making install in debian
make[1]: Entering directory `/s3backer/debian'
make[2]: Entering directory `/s3backer/debian'
make[2]: Nothing to be done for `install-exec-am'.
make[2]: Nothing to be done for `install-data-am'.
make[2]: Leaving directory `/s3backer/debian'
make[1]: Leaving directory `/s3backer/debian'
make[1]: Entering directory `/s3backer'
make[2]: Entering directory `/s3backer'
 /bin/mkdir -p '/usr/bin'
  /usr/bin/install -c s3backer '/usr/bin'
 /bin/mkdir -p '/usr/share/doc/packages/s3backer'
 /usr/bin/install -c -m 644 CHANGES COPYING README INSTALL TODO '/usr/share/doc/packages/s3backer'
 /bin/mkdir -p '/usr/share/man/man1'
 /usr/bin/install -c -m 644 s3backer.1 '/usr/share/man/man1'
make[2]: Leaving directory `/s3backer'
make[1]: Leaving directory `/s3backer'
 ---> 940a9958abd1
Removing intermediate container db018a4a0bf5
Successfully built 940a9958abd1
```

- Run the container:
```bash
$ docker run --rm -it --privileged s3backer
root@52744d765c5e:/s3backer# s3backer -h
Usage:
        s3backer [options] bucket /mount/point
        s3backer --test [options] directory /mount/point
        s3backer --erase [options] bucket
        s3backer --reset-mounted-flag [options] bucket
...
```