### PR TITLE
Cache statistics

### DIFF
--- a/block_cache.h
+++ b/block_cache.h
@@ -36,6 +36,18 @@ struct block_cache_conf {
     log_func_t          *log;
 };
 
+/* Usage statistics for block_cache */
+/* 36 bytes for each block */
+struct block_cache_usage_stats {
+    uint16_t            num_reads;                /* Number of read operations */
+    uint64_t            cumulative_reads_time;    /* Sum of all the differences between read opeation times */
+    uint64_t            last_read_timestamp;      /* Last time we read this block */
+
+    uint16_t            num_writes;               /* Number of write operations */
+    uint64_t            cumulative_writes_time;   /* Sum of all the differences between writes opeation times */
+    uint64_t            last_write_timestamp;     /* Last time we wrote this block */
+}; 
+
 /* Statistics structure for block_cache */
 struct block_cache_stats {
     u_int               initial_size;
@@ -48,6 +60,7 @@ struct block_cache_stats {
     u_int               verified;
     u_int               mismatch;
     u_int               out_of_memory_errors;
+    struct block_cache_usage_stats *usage_stats;  /* Pointer to array of usage stats (for each block) */
 };
 
 /* block_cache.c */

--- a/hash.c
+++ b/hash.c
@@ -41,6 +41,8 @@ struct s3b_hash {
     u_int       maxkeys;            /* max capacity */
     u_int       numkeys;            /* number of keys in table */
     u_int       alen;               /* hash array length */
+    u_int       collisions;         /* Hash collisions */
+    u_int       replaces;           /* Correct hash replaces */
     void        *array[0];          /* hash array */
 };
 
@@ -106,7 +108,10 @@ s3b_hash_put(struct s3b_hash *hash, void *value)
             break;
         if (KEY(value2) == key) {
             VALUE(hash, i) = value;         /* replace existing value having the same key with new value */
+            hash->replaces++;
             return value2;
+        } else {
+            hash->collisions++; /* We have a collision */
         }
     }
     assert(hash->numkeys < hash->maxkeys);


### PR DESCRIPTION
Branched from 1.4.1 tag.

I implemented some stats for the upper filesystem block usage. For the entire filesystem (Yes! it will consume a lot of memory, 36 bytes per block in this implementation) we now track how many times each block has been read, and how many time it has been written. We also track the "cumulative" time between reads and writes, so in the output we can average them and gather some usage patterns.
I added also "collisions" and "replaces" in the hashtable implmementations.

TODO: Dump the usage stats (only used blocks just to shorten the output) and the hash collisions stats (better in another FUSE file?)
