### PR TITLE
README.md: fix `RunningTheDemo` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ In normal operation **s3backer** will log via `syslog(3)`.  When run with the `-
 
 ### OK, Where to Next?
 
-**[Try it out!](RunningTheDemo.md)** No Amazon S3 account is required.
+**[Try it out!](https://github.com/archiecobbs/s3backer/wiki/RunningTheDemo)** No Amazon S3 account is required.
 
 See the [ManPage](https://github.com/archiecobbs/s3backer/wiki/ManPage) for further documentation and the [CHANGES](https://github.com/archiecobbs/s3backer/blob/master/CHANGES) file for release notes.
 


### PR DESCRIPTION
The `Try it out!` link was referencing a file that does not exist. This
was changed to a link to the project Wiki.