### PR TITLE
Set automake to foreign

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@
 
 AC_INIT([s3backer FUSE filesystem backed by Amazon S3], [1.4.1], [https://github.com/archiecobbs/s3backer], [s3backer])
 AC_CONFIG_AUX_DIR(scripts)
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE(foreign)
 dnl AM_MAINTAINER_MODE
 AC_PREREQ(2.59)
 AC_PREFIX_DEFAULT(/usr)


### PR DESCRIPTION
The project is missing some files (NEWS, AUTHORS, ChangeLog) according to automake standards for GNU applications. The files are not really necessary or already exist with a different name. To avoid a GNU style directory I set automake to foreign mode.