### PR TITLE
Fix use-after-free

### DIFF
--- a/block_cache.c
+++ b/block_cache.c
@@ -1244,25 +1244,10 @@ block_cache_free_one(void *arg, void *value)
 static struct cache_entry *
 block_cache_verified(struct block_cache_private *priv, struct cache_entry *entry)
 {
-    struct cache_entry *new_entry;
-
     /* Sanity check */
     assert(entry->verify);
     assert(ENTRY_GET_STATE(entry) == CLEAN2 || ENTRY_GET_STATE(entry) == READING2);
 
-    /* Give back some memory; if we can't no big deal */
-    if ((new_entry = realloc(entry, sizeof(*entry))) == NULL)
-        goto done;
-
-    /* Update all references that point to the entry */
-    s3b_hash_put(priv->hashtable, new_entry);
-    if (ENTRY_IN_LIST(entry)) {
-        TAILQ_REMOVE(&priv->cleans, entry, link);
-        TAILQ_INSERT_TAIL(&priv->cleans, new_entry, link);
-    }
-    entry = new_entry;
-
-done:
     /* Mark entry as verified */
     entry->verify = 0;
     return entry;


### PR DESCRIPTION
I wrote this on Fri, 25 Apr 2014 against s3backer 1.3.7 when doing
consulting for SoftNAS. The details of this use-after-free have been
lost to time, but my recollection is that they had a crash where another
thread had the old pointer on the stack after realloc() had assigned a
new pointer. The solution was deleting this code.

I maintained copyright ownership of the "change" (really just deleting
code) as well as all other changes that I made for them. I am fully able
to submit it under the GPL. Back then, getting in touch with the project
maintainer was hard, but since I see it is on github, it is time to send
the patch.

Signed-off-by: Richard Yao <ryao@gentoo.org>