### PR TITLE
Set keep alives

### DIFF
--- a/http_io.c
+++ b/http_io.c
@@ -2378,6 +2378,7 @@ http_io_acquire_curl(struct http_io_private *priv, struct http_io *io)
     curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, (long)1);
+    curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, (long)60);
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long)config->timeout);
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, config->user_agent);


### PR DESCRIPTION
I wrote a variation of this in 2014 against s3backer 1.3.7 when doing
consulting for SoftNAS. They had encountered a situation where long lived
connections to s3 with no activity would fall out of router NAT tables. The
original patch has been lost to time (it had a shorter keep alive timeout), but
I reproduced it from memory.

I maintained copyright ownership of the "change" (really just 1 line) as well
as all other changes that I made for them. I am fully able to submit it under
the GPL. Back then, getting in touch with the project maintainer was hard, but
since I see it is on github, it is time to send the patch.

This probably should be reworked to make the keep alives configurable, but I
have other things to do, so I am just sending it as-is to raise awareness of
the NAT issue. Also, it should be mentioned that this fails to work with
curl versions older than 7.25.0, such as the one used by CentOS 6 if my
memory serves me correctly.

Signed-off-by: Richard Yao <ryao@gentoo.org>