### PR TITLE
Don't hard-code bash location

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Script to regenerate all the GNU auto* gunk.


### PR DESCRIPTION
On FreeBSD for example bash is in /usr/local/bin. Using
/usr/bin/env bash works on all platforms.