### PR TITLE
Retain preferred block range in block cache

### DIFF
--- a/block_cache.c
+++ b/block_cache.c
@@ -1008,6 +1008,7 @@ again:
             }
         }
         protect_start = protect_end = 0;
+        goto again;
     } else if ((entry = TAILQ_FIRST(&priv->cleans)) != NULL) {
         block_cache_free_entry(priv, &entry);
         goto again;

--- a/block_cache.h
+++ b/block_cache.h
@@ -50,6 +50,9 @@ struct block_cache_conf {
     u_int               perform_flush;
     const char          *cache_file;
     log_func_t          *log;
+    const char          *protect_range;
+    s3b_block_t         protect_start;
+    s3b_block_t         protect_end;
 };
 
 /* Statistics structure for block_cache */

--- a/dcache.c
+++ b/dcache.c
@@ -352,6 +352,7 @@ s3b_dcache_set_mount_token(struct s3b_dcache *priv, int32_t *old_valuep, int32_t
 void
 s3b_dcache_close(struct s3b_dcache *priv)
 {
+    if (priv == NULL) return;
     close(priv->fd);
     free(priv->zero_block);
     free(priv->filename);

--- a/s3b_config.c
+++ b/s3b_config.c
@@ -179,6 +179,9 @@ static struct s3b_config config = {
         .timeout=               S3BACKER_DEFAULT_BLOCK_CACHE_TIMEOUT,
         .read_ahead=            S3BACKER_DEFAULT_READ_AHEAD,
         .read_ahead_trigger=    S3BACKER_DEFAULT_READ_AHEAD_TRIGGER,
+        .protect_range=         NULL,
+        .protect_start=         0,
+        .protect_end=           0,
     },
 
     /* FUSE operations config */
@@ -283,6 +286,10 @@ static const struct fuse_opt option_list[] = {
     {
         .templ=     "--readAheadTrigger=%u",
         .offset=    offsetof(struct s3b_config, block_cache.read_ahead_trigger),
+    },
+    {
+        .templ=     "--blockCacheProtectRange=%s",
+        .offset=    offsetof(struct s3b_config, block_cache.protect_range),
     },
     {
         .templ=     "--blockCacheFile=%s",
@@ -1311,6 +1318,16 @@ validate_config(void)
     if (config.block_cache.cache_file == NULL && config.block_cache.recover_dirty_blocks) {
         warnx("`--blockCacheRecoverDirtyBlocks' requires specifying `--blockCacheFile'");
         return -1;
+    }
+    if (config.block_cache.protect_range != NULL) {
+        int status = sscanf(config.block_cache.protect_range, "%d-%d",
+                            &config.block_cache.protect_start, &config.block_cache.protect_end);
+        if (status != 2) {
+            warnx("unable to parse --blockCacheProtectRange, must be in the format 123-456");
+            return -1;
+        } else {
+            warnx("range: %d - %d", config.block_cache.protect_start, config.block_cache.protect_end);
+        }
     }
 
     /* Check mount point */

--- a/s3b_config.c
+++ b/s3b_config.c
@@ -1325,8 +1325,14 @@ validate_config(void)
         if (status != 2) {
             warnx("unable to parse --blockCacheProtectRange, must be in the format 123-456");
             return -1;
-        } else {
-            warnx("range: %d - %d", config.block_cache.protect_start, config.block_cache.protect_end);
+        } else if (! (config.block_cache.protect_end > config.block_cache.protect_start)) {
+            warnx("block cache protect range end (%d) is not after start (%d)",
+                  config.block_cache.protect_end, config.block_cache.protect_start);
+            return -1;
+        } else if ((config.block_cache.protect_end - config.block_cache.protect_start + 1)
+                   >= config.block_cache.cache_size) {
+            warnx("the block cache protected range is equal to or larger than the cache size."
+                  " This may cause reduced performance.");
         }
     }
 

--- a/s3backer.1
+++ b/s3backer.1
@@ -188,8 +188,9 @@ The block cache is configured by the following command line options:
 .Fl \-blockCacheThreads ,
 .Fl \-blockCacheTimeout ,
 .Fl \-blockCacheWriteDelay ,
+.Fl \-blockCacheRecoverDirtyBlocks ,
 and
-.Fl \-blockCacheRecoverDirtyBlocks .
+.Fl \-blockCacheProtectRange .
 .Ss Read Ahead
 .Nm
 implements a simple read-ahead algorithm in the block cache.
@@ -463,6 +464,15 @@ This is verified by checking a unique 32-bit mount token in the cache file again
 This flag requires
 .Fl \-blockCacheFile
 to be set.
+.It Fl \-blockCacheProtectRange=START-END
+Preferentially retain a range of blocks in the block cache from the range START to END inclusive.
+For example, the range `0-15' will retain the first sixteen blocks.
+.Pp
+This option can be used to improve performance and reduce read activity for certain known regions of the file.
+For example, files hosting filesystems may prefer to retain blocks containing filesystem metadata.
+.Pp
+If the protected range is larger than the cache size, cache pressure may evict blocks within the protected range once the cache is full.
+Therefore, it is recommended that the cache size be larger than the protected range.
 .It Fl \-blockHashPrefix
 Prepend random prefixes (generated deterministically from the block number) to block object names.
 This spreads requests more evenly across the namespace, and prevents heavy access to a narrow range of blocks from all being directed to the same backend server.


### PR DESCRIPTION
In my use case, I'm using s3backer to host an HFS+ volume (for a Time Machine backup). HFS+ stores its metadata in a preferred metadata zone at the beginning of the filesystem. I would prefer that these metadata blocks be retained in my block cache to minimize the number of reads that take place in the course of a backup operation - a metadata-read heavy workload.

This PR implements the `--blockCacheProtectRange` option, which designates a range of blocks to be preferentially retained in the cache. The `block_cache_get_entry()` function is updated so that if the cache is full and the protected range is enabled, it walks down the list of cache entries to find the first block outside of the protected range to release. If all blocks are in the protected range, it falls back to the default behavior. This has the effect of releasing the least recently used block that is outside of the protected range.

This PR also has a very minor bugfix in `dcache.c` where a segfault is thrown when the block cache file path cannot be opened.