### PR TITLE
Feature: Add support for ONEZONE_IA

### DIFF
--- a/http_io.h
+++ b/http_io.h
@@ -45,6 +45,7 @@
 /* Storage classes */
 #define STORAGE_CLASS_STANDARD              "STANDARD"
 #define STORAGE_CLASS_STANDARD_IA           "STANDARD_IA"
+#define STORAGE_CLASS_ONEZONE_IA            "ONEZONE_IA"
 #define STORAGE_CLASS_REDUCED_REDUNDANCY    "REDUCED_REDUNDANCY"
 
 /* Server side encryption types */

--- a/s3b_config.c
+++ b/s3b_config.c
@@ -1216,6 +1216,7 @@ validate_config(void)
     if (config.http_io.storage_class != NULL
       && strcmp(config.http_io.storage_class, STORAGE_CLASS_STANDARD) != 0
       && strcmp(config.http_io.storage_class, STORAGE_CLASS_STANDARD_IA) != 0
+      && strcmp(config.http_io.storage_class, STORAGE_CLASS_ONEZONE_IA) != 0
       && strcmp(config.http_io.storage_class, STORAGE_CLASS_REDUCED_REDUNDANCY) != 0) {
         warnx("invalid storage class `%s'", config.http_io.storage_class);
         return -1;

--- a/s3backer.1
+++ b/s3backer.1
@@ -863,6 +863,7 @@ Specify storage class.
 Valid values are:
 .Pa STANDARD ,
 .Pa STANDARD_IA ,
+.Pa ONEZONE_IA ,
 and
 .Pa REDUCED_REDUNDANCY .
 .Pp


### PR DESCRIPTION
This enables support for users to directly configure `ONEZONE_IA` as a
target storage class for files placed into S3.  This is important
because when using LifeCycle policies users are forced to keep content
in a higher storage class for a minimum of 30 days.

When specified at the actual client level, content can be immediately
specified as the preferred storage class.


----
AWS information on [One Zone IA (Infrequent Access)](https://aws.amazon.com/s3/storage-classes/)