### PR TITLE
Fix a use-after-free case

### DIFF
--- a/http_io.c
+++ b/http_io.c
@@ -991,6 +991,8 @@ http_io_xml_text(void *arg, const XML_Char *s, int len)
         return;
     }
 
+    io->xml_text = new_buf;
+
     /* Append text to buffer */
     memcpy(io->xml_text + current_len, s, len);
     io->xml_text[current_len + len] = '\0';


### PR DESCRIPTION
`realloc` free's the old buffer, so io->xml_text should point to the
new buffer, or accessing by io->xml_text will error out.

Detected by sanitizer:
==25092==ERROR: AddressSanitizer: heap-use-after-free on address 0x60200007a010 at pc 0x7f5321b1ce6f bp 0x7f53097e8f40 sp 0x7f53097e86e8
WRITE of size 12 at 0x60200007a010 thread T42
    #0 0x7f5321b1ce6e in __interceptor_memcpy /build/gcc/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827
    #1 0x55bf1038580c in http_io_xml_text /home/zsx/s3backer.git/http_io.c:995
    #2 0x7f5321a659da  (/usr/lib/libexpat.so.1+0xd9da)
    #3 0x7f5321a68462  (/usr/lib/libexpat.so.1+0x10462)
    #4 0x7f5321a693d7  (/usr/lib/libexpat.so.1+0x113d7)
    #5 0x7f5321a60c80 in XML_ParseBuffer (/usr/lib/libexpat.so.1+0x8c80)
    #6 0x55bf10383177 in http_io_curl_xml_reader /home/zsx/s3backer.git/http_io.c:865
    #7 0x7f53217255f5  (/usr/lib/libcurl.so.4+0x4b5f5)
    #8 0x7f532170d6d5  (/usr/lib/libcurl.so.4+0x336d5)
    #9 0x7f5321737fd1  (/usr/lib/libcurl.so.4+0x5dfd1)
    #10 0x7f532171d3b4  (/usr/lib/libcurl.so.4+0x433b4)
    #11 0x7f532171eb45 in curl_multi_perform (/usr/lib/libcurl.so.4+0x44b45)
    #12 0x7f53216f6e4b in curl_easy_perform (/usr/lib/libcurl.so.4+0x1ce4b)
    #13 0x55bf10396b4f in http_io_perform_io /home/zsx/s3backer.git/http_io.c:2278
    #14 0x55bf1039572c in http_io_xml_io_exec /home/zsx/s3backer.git/http_io.c:2196
    #15 0x55bf10382a7e in http_io_list_blocks_range /home/zsx/s3backer.git/http_io.c:814
    #16 0x55bf10381630 in http_io_list_blocks_worker_main /home/zsx/s3backer.git/http_io.c:735
    #17 0x7f5320d4e258 in start_thread (/usr/lib/libpthread.so.0+0x9258)
    #18 0x7f5320c775e2 in __GI___clone (/usr/lib/libc.so.6+0xfe5e2)

0x60200007a011 is located 0 bytes to the right of 1-byte region [0x60200007a010,0x60200007a011)
freed by thread T42 here:
    #0 0x7f5321b9a652 in __interceptor_realloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:164
    #1 0x55bf103854d3 in http_io_xml_text /home/zsx/s3backer.git/http_io.c:988
    #2 0x7f5321a659da  (/usr/lib/libexpat.so.1+0xd9da)

previously allocated by thread T42 here:
    #0 0x7f5321b9a459 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x55bf10394e3d in http_io_xml_io_init /home/zsx/s3backer.git/http_io.c:2150
    #2 0x55bf10381f67 in http_io_list_blocks_range /home/zsx/s3backer.git/http_io.c:773
    #3 0x55bf10381630 in http_io_list_blocks_worker_main /home/zsx/s3backer.git/http_io.c:735
    #4 0x7f5320d4e258 in start_thread (/usr/lib/libpthread.so.0+0x9258)