### PR TITLE
Check returns of pthread_mutex_init in tester.c

### DIFF
--- a/tester.c
+++ b/tester.c
@@ -94,7 +94,10 @@ main(int argc, char **argv)
 
     /* Random initialization */
     srandom((u_int)time(NULL));
-    pthread_mutex_init(&mutex, NULL);
+    
+    if(pthread_mutex_init(&mutex, NULL)!=0)
+        err(1, "lock initialization");
+    
     start_time = get_time();
 
     /* Zero all blocks */


### PR DESCRIPTION
It seems there is only one place (tester.c) where the return values of pthread_mutex_init are not checked. This PR makes code more consistent.