### PR TITLE
Add zstd compression

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -36,12 +36,20 @@
 
 #include "s3backer.h"
 #include "compress.h"
-
+#ifdef ZSTD
+ #include <zstd.h>
+#endif
 // Deflate
 static comp_cfunc_t    deflate_compress;
 static comp_dfunc_t    deflate_decompress;
 static comp_lparse_t   deflate_lparse;
 static comp_lfree_t    deflate_lfree;
+
+// zstd
+static comp_cfunc_t    zstd_compress;
+static comp_dfunc_t    zstd_decompress;
+static comp_lparse_t   zstd_lparse;
+static comp_lfree_t    zstd_lfree;
 
 // Compression algorithms
 const struct comp_alg comp_algs[] = {
@@ -55,6 +63,15 @@ const struct comp_alg comp_algs[] = {
         .lparse=    deflate_lparse,
         .lfree=     deflate_lfree
     }
+#ifdef ZSTD
+    , {
+        .name=      "zstd",
+        .cfunc=     zstd_compress,
+        .dfunc=     zstd_decompress,
+        .lparse=    zstd_lparse,
+        .lfree=     zstd_lfree
+    }
+#endif
 };
 const size_t num_comp_algs = sizeof(comp_algs) / sizeof(*comp_algs);
 
@@ -187,6 +204,96 @@ invalid:
 
 static void
 deflate_lfree(void *level)
+{
+    free(level);
+}
+
+/****************************************************************************
+ *                                   ZSTD                                   *
+ ****************************************************************************/
+
+static int
+zstd_compress(log_func_t *log, const void *input, size_t inlen, void **outputp, size_t *outlenp, void *levelp)
+{
+    u_long clen;
+    void *cbuf;
+    int level;
+    int r;
+
+    // Allocate buffer
+    clen = ZSTD_compressBound(inlen);
+    if ((cbuf = malloc(clen)) == NULL) {
+        r = errno;
+        (*log)(LOG_ERR, "malloc: %s", strerror(r));
+        return r;
+    }
+
+    // Extract compression level
+    level = levelp != NULL ? *(int *)levelp : ZSTD_defaultCLevel();
+
+    // Compress data
+    clen = ZSTD_compress(cbuf, clen, input, inlen, level);
+
+    if(ZSTD_isError(clen)) {
+        (*log)(LOG_ERR, "zstd compress: error, %s", ZSTD_getErrorName(clen));
+        r = EIO;
+    } else {
+        *outputp = cbuf;
+        *outlenp = clen;
+        return 0;
+    }
+
+    // Fail
+    free(cbuf);
+    return r;
+}
+
+static int
+zstd_decompress(log_func_t *log, const void *input, size_t inlen, void *output, size_t *outlenp)
+{
+    size_t code = ZSTD_decompress(output, *outlenp, input, inlen);
+    if(ZSTD_isError(code)) {
+        (*log)(LOG_ERR, "zstd uncompress: %s", ZSTD_getErrorName(code));
+        return EIO;
+    }
+    *outlenp = code;
+    return 0;
+}
+
+static void *
+zstd_lparse(const char *string)
+{
+    char *endptr;
+    long level;
+    int *levelp;
+
+    // Parse level
+    errno = 0;
+    level = strtol(string, &endptr, 10);
+    if ((errno == ERANGE && (level == LONG_MIN || level == LONG_MAX))
+      || (errno != 0 && level == 0)
+      || *endptr != '\0'
+      || (int)level != level)
+        goto invalid;
+
+    // Check level
+    if( level < ZSTD_minCLevel() || level > ZSTD_maxCLevel())
+        goto invalid;
+
+    // Store in buffer
+    if ((levelp = malloc(sizeof(*levelp))) == NULL)
+        warn("malloc");
+    else
+        *levelp = (int)level;
+    return levelp;
+
+invalid:
+    warnx("invalid zstd compression level `%s'", string);
+    return NULL;
+}
+
+static void
+zstd_lfree(void * level)
 {
     free(level);
 }

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,12 @@ PKG_CHECK_MODULES(FUSE, fuse,
     LDFLAGS="${LDFLAGS} ${FUSE_LIBS}"],
     [AC_MSG_ERROR(["fuse" not found in pkg-config])])
 
+# Check for zstd
+PKG_CHECK_MODULES([ZSTD], libzstd,
+    [AC_DEFINE([ZSTD], [1], [Whether zstd is available]),
+    [CFLAGS="${CFLAGS} ${ZSTD_CFLAGS}"
+    LDFLAGS="${LDFLAGS} ${ZSTD_LIBS}"]])
+
 # Check for NBDKit
 PKG_CHECK_MODULES([NBDKIT], [nbdkit >= 1.24.1],
     [AC_DEFINE([NBDKIT], [1], [Whether NBDKit is available])

--- a/tester.c
+++ b/tester.c
@@ -88,6 +88,8 @@ main(int argc, char **argv)
     if ((store = s3backer_create_store(config)) == NULL)
         err(1, "s3backer_create_store");
 
+    store->create_threads(store);
+
     // Allocate block states
     if ((blocks = calloc(config->num_blocks, sizeof(*blocks))) == NULL)
         err(1, "calloc");


### PR DESCRIPTION
zstd is always faster than deflate whatever the target compression level. It also often compress better.

While testing zstd I also found a small bug in tester for which I provide patch.