### PR TITLE
Enable macOS builds

### DIFF
--- a/s3backer.h
+++ b/s3backer.h
@@ -90,6 +90,10 @@
 #include <zlib.h>
 #include <fuse.h>
 
+#ifdef __APPLE__
+extern char **environ;
+#endif
+
 #ifndef FUSE_OPT_KEY_DISCARD
 #define FUSE_OPT_KEY_DISCARD -4
 #endif


### PR DESCRIPTION
macOS requires explicit `environ` declaration.