### PR TITLE
Fix missing include for sys/prctl.h for PR_SET_IO_FLUSHER

### DIFF
--- a/s3backer.h
+++ b/s3backer.h
@@ -41,6 +41,9 @@
 #if HAVE_SYS_STATVFS_H
 #include <sys/statvfs.h>
 #endif
+#if HAVE_DECL_PR_SET_IO_FLUSHER
+#include <sys/prctl.h>
+#endif
 #include <sys/queue.h>
 #include <sys/wait.h>
 


### PR DESCRIPTION
Build currently fails on my machine, this fixes it.