### PR TITLE
Fix FreeBSD compatibility

### DIFF
--- a/s3backer.h
+++ b/s3backer.h
@@ -93,7 +93,7 @@
 #include <zlib.h>
 #include <fuse.h>
 
-#ifdef __APPLE__
+#if defined __APPLE__ || defined __FreeBSD__
 extern char **environ;
 #endif
 


### PR DESCRIPTION
FreeBSD also needs this `extern char **environ;` for s3backer to build properly.