### PR TITLE
fix: use non-deprecated curl constant in http_io.c

### DIFF
--- a/http_io.c
+++ b/http_io.c
@@ -2438,7 +2438,7 @@ http_io_perform_io(struct http_io_private *priv, struct http_io *io, http_io_cur
 
             // Extract content-length (if required)
             if (io->content_lengthp != NULL) {
-                if ((curl_code = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &clen)) == CURLE_OK)
+                if ((curl_code = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &clen)) == CURLE_OK)
                     *io->content_lengthp = (u_int)clen;
                 else {
                     (*config->log)(LOG_ERR, "can't get content-length: %s", curl_easy_strerror(curl_code));


### PR DESCRIPTION
Using libcurl 8.10.1, compiling fails with the following error:

```
6.962 http_io.c: In function 'http_io_perform_io':
6.962 http_io.c:2441:17: error: 'CURLINFO_CONTENT_LENGTH_DOWNLOAD' is deprecated: since 7.55.0. Use CURLINFO_CONTENT_LENGTH_DOWNLOAD_T [-Werror=deprecated-declarations]
6.962  2441 |                 if ((curl_code = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &clen)) == CURLE_OK)
6.962       |                 ^~
```

This commit fixes the warning as per instructions.