### PR TITLE
http_io: allow configuration of IP TOS (Type Of Service) byte value

### DIFF
--- a/http_io.c
+++ b/http_io.c
@@ -3301,7 +3301,8 @@ http_io_acquire_curl(struct http_io_private *priv, struct http_io *io)
       || !http_io_curl_setopt_long(priv, curl, CURLOPT_TIMEOUT, config->timeout)
       || !http_io_curl_setopt_long(priv, curl, CURLOPT_NOPROGRESS, 1)
       || !http_io_curl_setopt_ptr(priv, curl, CURLOPT_USERAGENT, config->user_agent)
-      || !http_io_curl_setopt_ptr(priv, curl, CURLOPT_SOCKOPTFUNCTION, http_io_sockopt_callback))
+      || !http_io_curl_setopt_ptr(priv, curl, CURLOPT_SOCKOPTFUNCTION, http_io_sockopt_callback)
+      || !http_io_curl_setopt_ptr(priv, curl, CURLOPT_SOCKOPTDATA, priv))
         goto optfail;
     if (config->max_speed[HTTP_UPLOAD] != 0
       && !http_io_curl_setopt_off(priv, curl, CURLOPT_MAX_SEND_SPEED_LARGE, (curl_off_t)(config->max_speed[HTTP_UPLOAD] / 8)))
@@ -3475,7 +3476,14 @@ http_io_curl_setopt_off(struct http_io_private *priv, CURL *curl, CURLoption opt
 static int
 http_io_sockopt_callback(void *cookie, curl_socket_t fd, curlsocktype purpose)
 {
+    struct http_io_private *const priv = cookie;
+    struct http_io_conf *const config = priv->config;
+
     (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
+
+    if (config->ip_tos > 0)
+        setsockopt(fd, IPPROTO_IP, IP_TOS, &config->ip_tos, sizeof(config->ip_tos));
+
     return CURL_SOCKOPT_OK;
 }
 

--- a/http_io.h
+++ b/http_io.h
@@ -80,6 +80,7 @@ struct http_io_conf {
     int                     debug;
     int                     debug_http;
     int                     http_11;                    // restrict to HTTP 1.1
+    int                     ip_tos;
     int                     quiet;
     int                     no_curl_cache;              // don't cache cURL handles
     const struct comp_alg   *compress_alg;              // compression algorithm, or NULL for none

--- a/s3b_config.c
+++ b/s3b_config.c
@@ -370,6 +370,10 @@ static const struct fuse_opt option_list[] = {
         .value=     1
     },
     {
+        .templ=     "--ipTOS=%d",
+        .offset=    offsetof(struct s3b_config, http_io.ip_tos),
+    },
+    {
         .templ=     "--noCurlCache",
         .offset=    offsetof(struct s3b_config, http_io.no_curl_cache),
         .value=     1
@@ -2068,6 +2072,7 @@ dump_config(const struct s3b_config *const c)
       c->max_speed_str[HTTP_DOWNLOAD] != NULL ? c->max_speed_str[HTTP_DOWNLOAD] : "-",
       c->http_io.max_speed[HTTP_DOWNLOAD]);
     (*c->log)(LOG_DEBUG, "%24s: %s", "http_11", c->http_io.http_11 ? "true" : "false");
+    (*c->log)(LOG_DEBUG, "%24s: %d", "ip_tos", c->http_io.ip_tos);
     (*c->log)(LOG_DEBUG, "%24s: %s", "noCurlCache", c->http_io.no_curl_cache ? "true" : "false");
     (*c->log)(LOG_DEBUG, "%24s: %us", "timeout", c->http_io.timeout);
     (*c->log)(LOG_DEBUG, "%24s: \"%s\"", "sse", c->http_io.sse);

--- a/s3b_config.c
+++ b/s3b_config.c
@@ -2162,6 +2162,7 @@ usage(void)
     fprintf(stderr, "\t--%-27s %s\n", "noCurlCache", "Disable caching of cURL handles");
     fprintf(stderr, "\t--%-27s %s\n", "initialRetryPause=MILLIS", "Initial retry pause after stale data or server error");
     fprintf(stderr, "\t--%-27s %s\n", "insecure", "Don't verify SSL server identity");
+    fprintf(stderr, "\t--%-27s %s\n", "ipTOS=VALUE", "Set Type Of Service byte value of outgoing IP packets");
     fprintf(stderr, "\t--%-27s %s\n", "keyLength", "Override generated cipher key length");
     fprintf(stderr, "\t--%-27s %s\n", "listBlocks", "Auto-detect non-empty blocks at startup");
     fprintf(stderr, "\t--%-27s %s\n", "listBlocksThreads", "List blocks in parallel using this many threads");

--- a/s3backer.1.in
+++ b/s3backer.1.in
@@ -806,6 +806,10 @@ Equivalent to the
 .Fl \-insecure
 flag documented in
 .Xr curl 1 .
+.It Fl \-ipTOS=VALUE
+Set specified Type Of Service byte value in all outgoing IP packet headers.
+This could be useful for network traffic routing purposes.
+Default is to set no specific value, so that the Operating System default value will be used.
 .It Fl \-keyLength
 Override the length of the generated block encryption key.
 .Pp

--- a/s3backer.h
+++ b/s3backer.h
@@ -46,6 +46,8 @@
 #if HAVE_DECL_PRCTL
 #include <sys/prctl.h>
 #endif
+#include <sys/socket.h>
+#include <netinet/ip.h>
 
 // Add some queue.h definitions missing on Linux
 #ifndef LIST_FIRST


### PR DESCRIPTION
IP Type Of Service byte with some "uncommon" value provides the only easy way for network routers to distinguish s3backer traffic.
Note that TOS is not usually reflected by S3 servers, so network routers may need mark flows instead of just individual packets.